### PR TITLE
Normalise discount before using it to calculate new costs

### DIFF
--- a/Koha/Plugin/Com/Theke/GOBI.pm
+++ b/Koha/Plugin/Com/Theke/GOBI.pm
@@ -548,10 +548,10 @@ sub _prepare_order_data {
     # Get tax and discounts info from the vendor
     my $tax_rate     = $bookseller->tax_rate;
     my $discount     = $bookseller->discount // 0;
-    my $THE_discount = $discount / 100;
+    $discount /= 100;
 
     $order_data->{tax_rate} = $tax_rate;
-    $order_data->{discount} = $THE_discount;
+    $order_data->{discount} = $discount;
 
     if ($price) {
         if ( $bookseller->listincgst ) {


### PR DESCRIPTION
Previously, the raw discount value was used to calculate the discounted price. As it is typically greater than 1, this would lead to negative discounted prices.

This patch has been tested on a customer server.

Thanks to @jonathanfield for the detailed initial investigation on this issue, and for deploying the patch for testing.